### PR TITLE
Update: change assert implementation. Add DioPinConfig_t struct and DIO_configSizeGet function on DIO driver.

### DIFF
--- a/FirmwareCode/include/dio.h
+++ b/FirmwareCode/include/dio.h
@@ -1,14 +1,13 @@
 /**
  * @file dio.h
  * @author Jose Luis Figueroa
- * @brief The interface definition for the dio. This is the header file for 
- * the definition of the interface for a General Purpose Input Output on 
+ * @brief The interface definition for the DIO. This is the header file for 
+ * the definition of the interface for a digital input/output peripheral on 
  * a standard microcontroller.
- * @version 1.0
- * @date 2023-03-18
+ * @version 1.1
+ * @date 2025-03-24
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
- * 
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 #ifndef DIO_H_
@@ -19,6 +18,7 @@
 *****************************************************************************/
 #include <stdint.h>
 #include <stdio.h>
+//#define NDEBUG          /*To disable assert function*/  
 #include <assert.h>
 #include "dio_cfg.h"    /*For dio configuration*/
 #include "stm32f4xx.h"  /*Microcontroller family header*/  
@@ -26,7 +26,6 @@
 /*****************************************************************************
 * Preprocessor Constants
 *****************************************************************************/
-#define DIO_ERROR_CODE_NONE 0x0000U /**< No error code*/
 
 /*****************************************************************************
 * Configuration Constants
@@ -39,6 +38,11 @@
 /*****************************************************************************
 * Typedefs
 *****************************************************************************/
+typedef struct
+{
+    DioPort_t Port;             /**< The I/O port */
+    DioPin_t Pin;               /**< The I/O pin */
+}DioPinConfig_t;
 
 /*****************************************************************************
 * Variables
@@ -51,10 +55,10 @@
 extern "C"{
 #endif
 
-void DIO_init(const DioConfig_t * const Config);
-DioPinState_t DIO_pinRead(DioPort_t Port, DioPin_t Pin);
-void DIO_pinWrite(DioPort_t Port, DioPin_t Pin, DioPinState_t State);
-void DIO_pinToggle(DioPort_t Port, DioPin_t Pin);
+void DIO_init(const DioConfig_t * const Config, size_t configSize);
+DioPinState_t DIO_pinRead(const DioPinConfig_t * const PinConfig);
+void DIO_pinWrite(const DioPinConfig_t * const PinConfig, DioPinState_t State);
+void DIO_pinToggle(const DioPinConfig_t * const PinConfig);
 void DIO_registerWrite(uint32_t address, uint32_t value);
 uint32_t DIO_registerRead(uint32_t address);
 

--- a/FirmwareCode/include/dio_cfg.h
+++ b/FirmwareCode/include/dio_cfg.h
@@ -4,10 +4,10 @@
  * @brief This module contains interface definitions for the Dio 
  * configuration. This is the header file for the definition of the
  * interface for retrieving the digital input/output configuration table.
- * @version 1.0
- * @date 2023-03-16
+ * @version 1.1
+ * @date 2025-03-24
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 #ifndef DIO_CFG_H_
@@ -16,6 +16,7 @@
 /*****************************************************************************
 * Includes
 *****************************************************************************/
+#include <stdio.h>
 
 /*****************************************************************************
 * Preprocessor Constants
@@ -24,11 +25,6 @@
  * Defines the number of ports on the processor.
  */
 #define NUMBER_OF_PORTS 5U
-
-/** Set the value according with the number of digital input/output peripheral
- * channel (pins) used.
-*/
-#define NUMBER_DIGITAL_PINS 2U
 
 /*****************************************************************************
 * Typedefs
@@ -212,6 +208,7 @@ extern "C"{
 #endif
 
 const DioConfig_t * const DIO_configGet(void);
+size_t DIO_configSizeGet(void);
 
 #ifdef __cplusplus
 } //extern "C"

--- a/FirmwareCode/src/dio.c
+++ b/FirmwareCode/src/dio.c
@@ -1,12 +1,11 @@
 /**
  * @file dio.c
  * @author Jose Luis Figueroa
- * @brief The implementation for the dio module. This is the General Purpose 
- * input/output module for a standard microcontroller.
- * @version 1.0
- * @date 2023-03-19
+ * @brief The implementation for the DIO driver.
+ * @version 1.1
+ * @date 2025-03-24
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 /*****************************************************************************
@@ -25,17 +24,6 @@
 /*****************************************************************************
 * Module Typedefs
 *****************************************************************************/
-typedef enum
-{
-    DIO_ERROR_CODE_PORT=1,      /**< Invalid port*/
-    DIO_ERROR_CODE_PIN,         /**< Invalid pin*/
-    DIO_ERROR_CODE_MODE,        /**< Invalid mode*/
-    DIO_ERROR_CODE_TYPE,        /**< Invalid type*/
-    DIO_ERROR_CODE_SPEED,       /**< Invalid speed*/
-    DIO_ERROR_CODE_RESISTOR,    /**< Invalid resistor*/
-    DIO_ERROR_CODE_FUNCTION,    /**< Invalid function*/
-    DIO_ERROR_CODE_MAX          /**< Maximum error*/
-}DioCodeError_t;
 
 /*****************************************************************************
 * Module Variable Definitions
@@ -72,9 +60,7 @@ static uint32_t volatile * const pupdrRegister[NUMBER_OF_PORTS] =
     (uint32_t*)&GPIOH->PUPDR
 };
 
-/*
- * Defines a array of pointers to the GPIO port input data register.
-*/
+/* Defines a array of pointers to the GPIO port input data register. */
 static uint32_t volatile * const idrRegister[NUMBER_OF_PORTS] =  
 {
     (uint32_t*)&GPIOA->IDR, (uint32_t*)&GPIOB->IDR, (uint32_t*)&GPIOC->IDR,
@@ -98,9 +84,6 @@ static uint32_t volatile * const afrRegister[NUMBER_OF_PORTS] =
     (uint32_t*)&GPIOH->AFR[0]
 };
 
-/*Define the error code flag*/
-volatile uint8_t DIO_errorCodeFlag = DIO_ERROR_CODE_NONE; /**< Error code flag*/
-
 /*****************************************************************************
 * Function Prototypes
 *****************************************************************************/
@@ -112,27 +95,33 @@ volatile uint8_t DIO_errorCodeFlag = DIO_ERROR_CODE_NONE; /**< Error code flag*/
  * Function: DIO_init()
 *//**
 *\b Description:
- * This function is used to initialize the Dio based on the configuration  
+ * This function is used to initialize the DIO based on the configuration  
  * table defined in dio_cfg module.
  * 
- * PRE-CONDITION: The MCU clocks must be configured and enabled.
- * PRE-CONDITION: NUMBER_OF_PORTS > 0 <br>
+ * PRE-CONDITION: The MCU clocks must be configured and enabled. <br>
  * PRE-CONDITION: Configuration table needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: NUMBER_OF_PORTS > 0 <br>
+ * PRE-CONDITION: The setting is within the maximum values (DIO_MAX). <br>
  * 
  * POST-CONDITION: The DIO peripheral is set up with the configuration 
  * settings.
  * 
  * @param[in]   Config is a pointer to the configuration table that contains 
  *               the initialization for the peripheral.
+ * @param[in]   configSize is the size of the configuration table.
  * 
  * @return  void
  * 
  * \b Example:
  * @code
- *  const DioConfig_t * const DioConfig = DIO_configGet();
- *  DIO_init(DioConfig);
+ * const Dio_ConfigType_t * const DioConfig = DIO_configGet();
+ * size_t configSize = DIO_configSizeGet();
+ * 
+ * DIO_Init(DioConfig, configSize);
  * @endcode
  * 
+ * @see DIO_configGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_pinRead
  * @see DIO_pinWrite
@@ -141,17 +130,17 @@ volatile uint8_t DIO_errorCodeFlag = DIO_ERROR_CODE_NONE; /**< Error code flag*/
  * @see DIO_registerRead
  * 
 *****************************************************************************/
-void DIO_init(const DioConfig_t * const Config)
+void DIO_init(const DioConfig_t * const Config, size_t configSize)
 {
     /* Loop through all the elements of the configuration table. */
-    for(uint8_t i=0; i<NUMBER_DIGITAL_PINS; i++)
+    for(uint8_t i=0; i<configSize; i++)
     {
-        /*Check the USART port*/
-        if(Config[i].Port >= DIO_MAX_PORT)
-        {
-            DIO_errorCodeFlag = DIO_ERROR_CODE_PORT;
-            assert(DIO_errorCodeFlag != DIO_ERROR_CODE_PORT);
-        }
+        /* Prevent to assign a value out of the range of the port and pin.
+         * The registers arrays are limited to the NUMBER_OF_PORTS, higher 
+         * value can cause a memory violation.
+        */
+        assert(Config[i].Port < DIO_MAX_PORT);
+        assert(Config[i].Pin < DIO_MAX_PIN);
 
         /* 
          * Set the mode of the Dio pin on the GPIO port mode register. 
@@ -181,8 +170,7 @@ void DIO_init(const DioConfig_t * const Config)
         }
         else
         {
-            DIO_errorCodeFlag = DIO_ERROR_CODE_PIN;
-            assert(DIO_errorCodeFlag != DIO_ERROR_CODE_PIN);
+            assert(Config[i].Mode < DIO_MAX_MODE);
         }
 
         /*
@@ -199,8 +187,7 @@ void DIO_init(const DioConfig_t * const Config)
         }
         else
         {
-            DIO_errorCodeFlag = DIO_ERROR_CODE_TYPE;
-            assert(DIO_errorCodeFlag != DIO_ERROR_CODE_TYPE);
+            assert(Config[i].Type < DIO_MAX_TYPE);
         }
 
         /*
@@ -230,8 +217,7 @@ void DIO_init(const DioConfig_t * const Config)
         }
         else
         {
-            DIO_errorCodeFlag = DIO_ERROR_CODE_SPEED;
-            assert(DIO_errorCodeFlag != DIO_ERROR_CODE_SPEED);
+            assert(Config[i].Speed < DIO_MAX_SPEED);
         }
 
         /*
@@ -257,8 +243,7 @@ void DIO_init(const DioConfig_t * const Config)
        }
        else
        {
-            DIO_errorCodeFlag = DIO_ERROR_CODE_RESISTOR;
-            assert(DIO_errorCodeFlag != DIO_ERROR_CODE_RESISTOR);
+            assert(Config[i].Resistor < DIO_MAX_RESISTOR);
        }
 
         /*
@@ -380,9 +365,8 @@ void DIO_init(const DioConfig_t * const Config)
        }
        else
        {
-            DIO_errorCodeFlag = DIO_ERROR_CODE_FUNCTION;
-            assert(DIO_errorCodeFlag != DIO_ERROR_CODE_FUNCTION);
-       } 
+            assert(Config[i].Function < DIO_MAX_FUNCTION);
+       }
 
     }
 }
@@ -391,25 +375,36 @@ void DIO_init(const DioConfig_t * const Config)
  * Function: DIO_pinRead()
 *//**
  *\b Description:
- * This function is used to read the state of a dio pin.
+ * This function is used to reads the state of a specified pin.
+ * This function reads the state of a digital input/output pin specified by
+ * the DioPinConfig_t structure, which contains the port and pin information.
  * 
  * PRE-CONDITION: The pin is configured as INPUT <br>
  * PRE-CONDITION: The pin is configured as GPIO <br>
- * PRE-CONDITION: The Port is within the maximum DioPort_t.
+ * PRE-CONDITION: DioPinConfig_t needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: The Port is within the maximum DioPort_t. <br>
  * PRE-CONDITION: The Pin is within the maximum DioPin_t. 
- * definition.
+ * definition. <br>
  * 
- * POST-CONDITION: The channel state is returned.
+ * POST-CONDITION: The channel state is returned. <br>
  * 
- * @param[in]   Port is the DioPort_t that represents a port.
- * @param[in]   Pin is the DioPin_t that represents a pin.
- * @return      The state of the channel as HIGH or LOW.
+ * @param[in] PinConfig A pointer to a structure containing the port and pin 
+ * to be read.
+ * 
+ * @return    DioPinState_t The state of the pin (high or low).
  * 
  * \b Example:
  * @code
- *  bool pin = DIO_pinRead(DIO_PC, DIO_PC5);
+ * const DioPinConfig_t  UserButton1= 
+ * {
+ *      .Port = DIO_PC, 
+ *      .Pin = DIO_PC13
+ * };
+ *  bool pin = DIO_pinRead(&UserButton1);
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_pinRead
  * @see DIO_pinWrite
@@ -418,12 +413,19 @@ void DIO_init(const DioConfig_t * const Config)
  * @see DIO_registerRead
  * 
 **********************************************************************/
-DioPinState_t DIO_pinRead(DioPort_t Port, DioPin_t Pin)
+DioPinState_t DIO_pinRead(const DioPinConfig_t * const PinConfig)
 {
+    /* Prevent to assign a value out of the range of the port and pin.
+     * The registers arrays are limited to the NUMBER_OF_PORTS, higher 
+     * value can cause a memory violation.
+    */
+    assert(PinConfig->Port < DIO_MAX_PORT);
+    assert(PinConfig->Pin < DIO_MAX_PIN);
+
     /* Read the port associated with the desired pin */
-    uint16_t portState = *idrRegister[Port];
+    uint16_t portState = *idrRegister[PinConfig->Port];
     /* Determinate the Port bit associated with this pin*/
-    uint16_t pinMask = (1UL<<(Pin));
+    uint16_t pinMask = (1UL<<(PinConfig->Pin));
 
     return ((portState & pinMask) ? DIO_HIGH : DIO_LOW); 
 }
@@ -433,31 +435,45 @@ DioPinState_t DIO_pinRead(DioPort_t Port, DioPin_t Pin)
 *//**
  *\b Description:
  * This function is used to write the state of a pin as either logic 
- * high or low through the use of the DioChannel_t enum to select the 
- * channel and the DioPinState_t to define the desired state.
+ * high or low. it reads the state of a digital input/output pin 
+ * specified by the DioPinConfig_t structure and the DioPinState_t to 
+ * define the desired state, which contains the port and pin 
+ * information.
  * 
  * PRE-CONDITION: The pin is configured as OUTPUT <br>
  * PRE-CONDITION: The pin is configured as GPIO <br>
- * PRE-CONDITION: The pin is within the maximum DioChannel_t .
- * definition.
+ * PRE-CONDITION: DioPinConfig_t needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: The Port is within the maximum DioPort_t. <br>
+ * PRE-CONDITION: The Pin is within the maximum DioPin_t. <br>
+ * PRE-CONDITION: The State is within the maximum DioPinState_t. <br>
  * 
- * POST-CONDITION: The channel state will be Stated.
+ * POST-CONDITION: The channel state is Stated. <br>
  * 
- * @param[in]   Port is the GPIO to write using the DioPort_t enum.
- * @param[in]   Pin is the bit to write using the DioPin_t enum 
- *              definition.
+ * @param[in]   pinConfig A pointer to a structure containing the port 
+ *              and pin to be written.
  * @param[in]   State is HIGH or LOW as defined in the DioPinState_t 
  *              enum. 
- *          
  * 
- * @return  void
+ * @return      void
  * 
  * \b Example:
  * @code
- *  DIO_pinWrite(DIO_PA, DIO_PA1, LOW);  //Set the PORT pin low
- *  DIO_pinWrite(DIO_PB, DIO_PB3, HIGH); //Set the PORT pin high
+ * const DioPinConfig_t  UserLED1= 
+ * {
+ *      .Port = DIO_PA, 
+ *      .Pin = DIO_PA5
+ * };
+ * const DioPinConfig_t  UserLED2= 
+ * {
+ *      .Port = DIO_PA, 
+ *      .Pin = DIO_PA6
+ * };
+ * DIO_pinWrite(&UserLED1, LOW);    //Set the pin low
+ * DIO_pinWrite(&UserLED2, HIGH);   //Set the pin high
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_pinRead
  * @see DIO_pinWrite
@@ -466,19 +482,26 @@ DioPinState_t DIO_pinRead(DioPort_t Port, DioPin_t Pin)
  * @see DIO_registerRead
  * 
  **********************************************************************/
-void DIO_pinWrite(DioPort_t Port, DioPin_t Pin, DioPinState_t State)
+void DIO_pinWrite(const DioPinConfig_t * const PinConfig, DioPinState_t State)
 {
+    /* Prevent to assign a value out of the range of the port and pin.
+     * The registers arrays are limited to the NUMBER_OF_PORTS, higher 
+     * value can cause a memory violation.
+    */
+    assert(PinConfig->Port < DIO_MAX_PORT);
+    assert(PinConfig->Pin < DIO_MAX_PIN);
+
     if(State == DIO_HIGH)
     {
-        *odrRegister[Port] |= (1UL<<(Pin));
+        *odrRegister[PinConfig->Port] |= (1UL<<(PinConfig->Pin));
     }
     else if (State == DIO_LOW)
     {
-        *odrRegister[Port] &= ~(1UL<<Pin);
+        *odrRegister[PinConfig->Port] &= ~(1UL<<(PinConfig->Pin));
     }
     else
     {
-        printf("This option does not exist");
+        assert(State < DIO_PIN_STATE_MAX);
     }
 }
 
@@ -486,25 +509,36 @@ void DIO_pinWrite(DioPort_t Port, DioPin_t Pin, DioPinState_t State)
  * Function: DIO_pinToggle()
 *//**
  *\b Description:
- * This function is used to toggle the current state of a pin.
+ * This function is used to toggle the current state of a pin. 
+ * This function reads the state of a digital input/output pin 
+ * specified by the DioPinConfig_t structure, which contains the port 
+ * and pin information.
  * 
  * PRE-CONDITION: The channel is configured as output <br>
  * PRE-CONDITION: The channel is configured as GPIO <br>
- * PRE-CONDITION: The channel is within the maximum DioChannel_t 
- * definition.
+ * PRE-CONDITION: DioPinConfig_t needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: The Port is within the maximum DioPort_t. <br>
+ * PRE-CONDITION: The Pin is within the maximum DioPin_t. <br>
  *
- * POST-CONDITION:
+ * POST-CONDITION: The channel state is toggled. <br>
  * 
- * @param[in]   Port is the GPIO to write using the DioPort_t enum.
- * @param[in]   Pin is the bit from the DioPin_t that is to be modified
+ * @param[in]   pinConfig A pointer to a structure containing the port 
+ *              and pin to be toggled.
  * 
  * @return  void
  * 
  * \b Example:
  * @code
- *  DIO_pinToggle(DIO_PA, DIO_PA3);
+ * const DioPinConfig_t  UserLED1= 
+ * {
+ *      .Port = DIO_PA, 
+ *      .Pin = DIO_PA5
+ * };
+ * DIO_pinToggle(&UserLED1);
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_pinRead
  * @see DIO_pinWrite
@@ -513,29 +547,36 @@ void DIO_pinWrite(DioPort_t Port, DioPin_t Pin, DioPinState_t State)
  * @see DIO_registerRead
  * 
  **********************************************************************/
-void DIO_pinToggle(DioPort_t Port, DioPin_t Pin)
+void DIO_pinToggle(const DioPinConfig_t * const PinConfig)
 {
-    *odrRegister[Port] ^= (1UL<<Pin);
+    /* Prevent to assign a value out of the range of the port and pin.
+     * The registers arrays are limited to the NUMBER_OF_PORTS, higher 
+     * value can cause a memory violation.
+    */
+    assert(PinConfig->Port < DIO_MAX_PORT);
+    assert(PinConfig->Pin < DIO_MAX_PIN);
+
+    *odrRegister[PinConfig->Port] ^= (1UL<<(PinConfig->Pin));
 }
 
 /**********************************************************************
  * Function: DIO_registerWrite()
 *//**
  *\b Description:
- * This function is used to directly address and modify a Dio register.
+ * This function is used to directly address and modify a GPIO register.
  * The function should be used to access specialized functionality in 
- * the Dio peripheral that is not exposed by any other function of the
+ * the DIO peripheral that is not exposed by any other function of the
  * interface.
  * 
- * PRE-CONDITION: Address is within the boundaries of the Dio register
- * address space.
+ * PRE-CONDITION: Address is within the boundaries of the DIO register
+ * address space. <br>
  * 
  * POST-CONDITION: The register located at address with be updated with
- * value.
+ * value. <br>
  * 
- * @param[in]   address is a register address within the Dio peripheral
+ * @param[in]   address is a register address within the DIO peripheral
  *              map.
- * @param[in]   value is the value to set the Dio register. 
+ * @param[in]   value is the value to set the DIO register. 
  * 
  * @return void
  * 
@@ -544,10 +585,12 @@ void DIO_pinToggle(DioPort_t Port, DioPin_t Pin)
  *  DIO_registerWrite(0x1000, 0x15);
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
- * @see DIO_channelRead
- * @see DIO_channelWrite
- * @see DIO_channelToggle
+ * @see DIO_pinRead
+ * @see DIO_pinWrite
+ * @see DIO_pinToggle
  * @see DIO_registerWrite
  * @see DIO_registerRead
  * 
@@ -568,10 +611,10 @@ void DIO_registerWrite(uint32_t address, uint32_t value)
  * interface.
  * 
  * PRE-CONDITION: Address is within the boundaries of the Dio register 
- * address space.
+ * address space. <br>
  * 
  * POST-CONDITION: The value stored in the register is returned to the 
- * caller.
+ * caller. <br>
  * 
  * @param[in]   address is the address of the Dio register to read.
  * 
@@ -582,10 +625,12 @@ void DIO_registerWrite(uint32_t address, uint32_t value)
  * type dioValue = DIO_registerRead(0x1000);
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
- * @see DIO_channelRead
- * @see DIO_channelWrite
- * @see DIO_channelToggle
+ * @see DIO_pinRead
+ * @see DIO_pinWrite
+ * @see DIO_pinToggle
  * @see DIO_registerWrite
  * @see DIO_registerRead
  *

--- a/FirmwareCode/src/dio_cfg.c
+++ b/FirmwareCode/src/dio_cfg.c
@@ -3,12 +3,12 @@
  * @author Jose Luis Figueroa
  * @brief This module contains the implementation for the digital 
  * input/output peripheral configuration.
- * @version 1.0
- * @date 2023-03-17
+ * @version 1.1
+ * @date 2025-03-19
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
-*/
+ */
 
 /*****************************************************************************
 * Module Includes
@@ -35,7 +35,7 @@
  * input/output peripheral channel (pin). Each row represent a single pin.
  * Each column is representing a member of the DioConfig_t structure. This 
  * table is read in by Dio_Init, where each channel is then set up based on 
- * this table.
+ * this table. 
 */
 const DioConfig_t DioConfig[] = 
 {
@@ -58,22 +58,27 @@ const DioConfig_t DioConfig[] =
  * Function: DIO_configGet()
 */
 /**
- *\b Description:
+*\b Description:
  * This function is used to initialize the DIO based on the configuration
  * table defined in dio_cfg module.
  * 
- * PRE-CONDITION: configuration table needs to be populated (sizeof > 0)
+ * PRE-CONDITION: configuration table needs to be populated (sizeof > 0) <br>
+ * 
  * POST-CONDITION: A constant pointer to the first member of the  
- * configuration table will be returned.
- * @return A pointer to the configuration table.
+ * configuration table will be returned.<br>
+ * 
+ * @return A pointer to the configuration table. <br>
  * 
  * \b Example: 
  * @code
- * const Dio_ConfigType_t * const DioConfig = DIO_configGet();
+ * const Dio_Config_t * const DioConfig = DIO_configGet();
+ * size_t configSize = DIO_configSizeGet();
  * 
- * DIO_Init(DioConfig);
+ * DIO_Init(DioConfig, configSize);
  * @endcode
  * 
+ * @see DIO_configGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_channelRead
  * @see DIO_channelWrite
@@ -90,4 +95,40 @@ const DioConfig_t * const DIO_configGet(void)
    */
   return (const DioConfig_t*)&DioConfig[0];
 
+}
+
+/*****************************************************************************
+ * Function: DIO_getConfigSize()
+*/
+/**
+*\b Description:
+ * This function is used to get the size of the configuration table.
+ * 
+ * PRE-CONDITION: configuration table needs to be populated (sizeof > 0) <br>
+ * 
+ * POST-CONDITION: The size of the configuration table will be returned. <br>
+ * 
+ * @return The size of the configuration table.
+ * 
+ * \b Example: 
+ * @code
+ * const Dio_Config_t * const DioConfig = DIO_configGet();
+ * size_t configSize = DIO_configSizeGet();
+ * 
+ * DIO_Init(DioConfig, configSize);
+ * @endcode
+ * 
+ * @see DIO_configGet
+ * @see DIO_configSizeGet
+ * @see DIO_init
+ * @see DIO_channelRead
+ * @see DIO_channelWrite
+ * @see DIO_channelToggle
+ * @see DIO_registerWrite
+ * @see DIO_registerRead
+ * 
+*****************************************************************************/
+size_t DIO_configSizeGet(void)
+{
+   return sizeof(DioConfig)/sizeof(DioConfig[0]);
 }


### PR DESCRIPTION
The assert macro implementation (design by contract) is added to catch bux on the development stage.

Modified function arguments to pass structures by pointer (DioPinConfig_t ) instead of by value. This reduces memory overhead and allows direct modification of struct members without unnecessary copies and a defensive programming approach.

The DIO_configSizeGet function was added to get the table size automatically.

The comments were updated according to the updates.