### PR TITLE
Update: change assert implementation. Add UsartTransferConfig_t struct and USART_configSizeGet function on USART driver.

### DIFF
--- a/FirmwareCode/include/usart.h
+++ b/FirmwareCode/include/usart.h
@@ -4,10 +4,10 @@
  * @brief The interface definition for the Universal Synchronous/Asynchronous 
  * Receiver Transmitter. This is the header file for the definition of the 
  * interface for a USART on a standard microcontroller.
- * @version 1.0
- * @date 2025-01-27
+ * @version 1.1
+ * @date 2025-03-24
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. All rights reserved.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. All rights reserved.
  * 
  */
 #ifndef USART_H_
@@ -25,7 +25,6 @@
 /*****************************************************************************
 * Preprocessor Constants
 *****************************************************************************/
-#define USART_ERROR_CODE_NONE   0x0000U /**< No error code*/
 
 /*****************************************************************************
 * Configuration Constants
@@ -38,6 +37,12 @@
 /*****************************************************************************
 * Typedefs
 *****************************************************************************/
+typedef struct 
+{
+    UsartPort_t Port;       /**< USART port*/
+    uint8_t *data;          /**< Data to be transmitted*/
+}UsartTransferConfig_t;
+
 
 /*****************************************************************************
 * Variables
@@ -50,9 +55,10 @@
 extern "C"{
 #endif
 
-void USART_init(const UsartConfig_t * const Config, const uint32_t peripheralClock);
-void USART_transmit(const UsartPort_t Port, const char * const data);
-void USART_receive(const UsartPort_t Port, char * const data);
+void USART_init(const UsartConfig_t * const Config, 
+const uint32_t peripheralClock, size_t configSize);  
+void USART_transmit(const UsartTransferConfig_t * const TransferConfig);
+void USART_receive(const UsartTransferConfig_t * const TransferConfig);
 void USART_registerWrite(const uint32_t address, const uint32_t value);
 uint32_t USART_registerRead(const uint32_t address);
 

--- a/FirmwareCode/include/usart_cfg.h
+++ b/FirmwareCode/include/usart_cfg.h
@@ -5,10 +5,10 @@
  * configuration. This is the header file for the definition of the
  * interface for retrieving the Universal Synchronous/Asynchronous Receiver
  * Transmitter configuration table.
- * @version 1.0
- * @date 2025-01-26
+ * @version 1.1
+ * @date 2025-03-24
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 #ifndef USART_CFG_H_
@@ -17,6 +17,7 @@
 /*****************************************************************************
  * Includes
 ******************************************************************************/
+#include <stdio.h>
 
 /*****************************************************************************
  * Preprocessor Constants
@@ -25,11 +26,6 @@
  * Defines the number of USART peripherals on the processor.
 */
 #define USART_PORTS_NUMBER 3U
-
-/** 
- * Set the value according with the number of USART peripheral
-*/
-#define USART_USED_PORTS 1U
 
 /*****************************************************************************
  * Typedefs
@@ -168,6 +164,7 @@ extern "C"{
 #endif
 
 const UsartConfig_t * const USART_configGet(void);
+size_t USART_configSizeGet(void);
 
 #ifdef __cplusplus
 } // extern C

--- a/FirmwareCode/src/dio.c
+++ b/FirmwareCode/src/dio.c
@@ -114,7 +114,7 @@ static uint32_t volatile * const afrRegister[NUMBER_OF_PORTS] =
  * 
  * \b Example:
  * @code
- * const Dio_ConfigType_t * const DioConfig = DIO_configGet();
+ * const DioConfigType_t * const DioConfig = DIO_configGet();
  * size_t configSize = DIO_configSizeGet();
  * 
  * DIO_Init(DioConfig, configSize);
@@ -415,10 +415,7 @@ void DIO_init(const DioConfig_t * const Config, size_t configSize)
 **********************************************************************/
 DioPinState_t DIO_pinRead(const DioPinConfig_t * const PinConfig)
 {
-    /* Prevent to assign a value out of the range of the port and pin.
-     * The registers arrays are limited to the NUMBER_OF_PORTS, higher 
-     * value can cause a memory violation.
-    */
+    /* Prevent to assign a value out of the range of the port and pin.*/
     assert(PinConfig->Port < DIO_MAX_PORT);
     assert(PinConfig->Pin < DIO_MAX_PIN);
 

--- a/FirmwareCode/src/dio_cfg.c
+++ b/FirmwareCode/src/dio_cfg.c
@@ -71,7 +71,7 @@ const DioConfig_t DioConfig[] =
  * 
  * \b Example: 
  * @code
- * const Dio_Config_t * const DioConfig = DIO_configGet();
+ * const DioConfig_t * const DioConfig = DIO_configGet();
  * size_t configSize = DIO_configSizeGet();
  * 
  * DIO_Init(DioConfig, configSize);
@@ -112,7 +112,7 @@ const DioConfig_t * const DIO_configGet(void)
  * 
  * \b Example: 
  * @code
- * const Dio_Config_t * const DioConfig = DIO_configGet();
+ * const DioConfig_t * const DioConfig = DIO_configGet();
  * size_t configSize = DIO_configSizeGet();
  * 
  * DIO_Init(DioConfig, configSize);

--- a/FirmwareCode/src/usart_cfg.c
+++ b/FirmwareCode/src/usart_cfg.c
@@ -3,10 +3,10 @@
  * @author Jose Luis Figueroa
  * @brief This module contains the implementation for the Universal 
  * Synchronous/Asynchronous Receiver Transmitter peripheral configuration.
- * @version 1.0
- * @date 2025-01-27
+ * @version 1.1
+ * @date 2025-03-24
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 /*****************************************************************************
@@ -63,18 +63,26 @@ const UsartConfig_t UsartConfig[] =
  * This function is used to initialize the USART based on the configuration 
  * table defined in usart_cfg module.
  * 
- * PRE-CONDITION: The configuration table needs to be populated (sizeof > 0)
+ * PRE-CONDITION: The configuration table needs to be populated (sizeof > 0) <br>
+ * 
  * POST-CONDITION: A constant pointer to the first member of the configuration
- * table is returned.
- * @return A pointer to the configuration table.
+ * table is returned. <br>
+ * 
+ * @return A pointer to the configuration table. <br>
  * 
  * \b Example:
  * @code
+ * #define SYSTEM_CLOCK    16000000
+ * #define APB1_CLOCK      SYSTEM_CLOCK
+ *
  * const UsartConfig_t * const UsartConfig = Usart_configGet();
+ * size_t configSize = USART_configSizeGet();
  * 
- * USART_Init(UsartConfig);
+ * USART_init(UsartConfig, APB1_CLOCK, configSize);
  * @endcode
  * 
+ * @see USART_ConfigGet
+ * @see USART_ConfigSizeGet
  * @see USART_Init
  * @see USART_Transmit
  * @see USART_Receive
@@ -90,4 +98,42 @@ const UsartConfig_t * const USART_configGet(void)
     */
     return (const UsartConfig_t *)&UsartConfig[0];
     
+}
+
+/*****************************************************************************
+ * Function: USART_getConfigSize()
+*/
+/**
+*\b Description:
+ * This function is used to get the size of the configuration table.
+ * 
+ * PRE-CONDITION: configuration table needs to be populated (sizeof > 0) <br>
+ * 
+ * POST-CONDITION: The size of the configuration table will be returned. <br>
+ * 
+ * @return The size of the configuration table.
+ * 
+ * \b Example: 
+ * @code
+ * #define SYSTEM_CLOCK    16000000
+ * #define APB1_CLOCK      SYSTEM_CLOCK
+ *
+ * const UsartConfig_t * const UsartConfig = Usart_configGet();
+ * size_t configSize = USART_configSizeGet();
+ * 
+ * USART_init(UsartConfig, APB1_CLOCK, configSize);
+ * @endcode
+ * 
+ * @see USART_configGet
+ * @see USART_configSizeGet
+ * @see USART_Init
+ * @see USART_Transmit
+ * @see USART_Receive
+ * @see USART_registerWrite
+ * @see USART_registerRead
+ * 
+*****************************************************************************/
+size_t USART_configSizeGet(void)
+{
+   return sizeof(UsartConfig)/sizeof(UsartConfig[0]);
 }

--- a/Workspace.code-workspace
+++ b/Workspace.code-workspace
@@ -8,5 +8,9 @@
 			"path": "FirmwareCode"
 		}
 	],
-	"settings": {}
+	"settings": {
+		"files.associations": {
+			"stdint.h": "c"
+		}
+	}
 }


### PR DESCRIPTION
The assert macro implementation (design by contract) is added to catch bux on the development stage.

Modified function arguments to pass structures by pointer (UsartTransferConfig_t) instead of by value. This reduces memory overhead and allows direct modification of struct members without unnecessary copies and a defensive programming approach.

The USART_configSizeGet function was added to get the table size automatically.

The comments were updated according to the updates.